### PR TITLE
Isse 2277 Fix : osconnect dataviewer keeps showing the elements info on cursor away

### DIFF
--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -790,6 +790,8 @@
     map.on("mousemove", async function (e) {
       const zoom = map.getZoom();
       if (zoom < 16) {
+        hoverPopup.close();
+        lastFeatureId = null;
         return;
       }
       // console.log(e.latlng);
@@ -814,8 +816,10 @@
             .openOn(map);
         }
       } else {
-        hoverPopup.closePopup();
-        lastFeatureId = null; // Reset last feature
+        if (lastFeatureId !== null) {
+          hoverPopup.close();
+          lastFeatureId = null;
+        }
       }
     });
     map.on('popupopen', (e) => {


### PR DESCRIPTION
[Issue-2277](https://dev.azure.com/TDEI-UW/WA%20Proviso/_workitems/edit/2277): The hover popup showing element details sometimes remains visible even after the mouse moves away from the element. 

Fix: The mousemove event listener has been updated to close the hoverPopup and reset the lastFeatureId when no features are detected at the mouse's new location.

Result: The hover popup will now reliably disappear when the cursor is no longer over an element.