### PR TITLE
Issue 2291-crossings seem to be wrong

### DIFF
--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -543,14 +543,11 @@
     }
 
     function getCrossingColor(d) {
-      if (d['crossing'] == 'marked') {
-        return '#FFD166';
-      }
-      else if (d['crossing'] == 'unmarked') {
-        return '#dda15e';
-      }
-      else {
-        return '#FFD166';
+      console.log("crossing", d);
+      if (d['crossing:markings'] == 'no') {
+        return '#dda15e'; // Unmarked crossing
+      } else {
+        return '#FFD166'; // Marked crossing
       }
     }
     function clearSearch() {

--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -543,7 +543,6 @@
     }
 
     function getCrossingColor(d) {
-      console.log("crossing", d);
       if (d['crossing:markings'] == 'no') {
         return '#dda15e'; // Unmarked crossing
       } else {


### PR DESCRIPTION
**Issue :** https://dev.azure.com/TDEI-UW/WA%20Proviso/_workitems/edit/2291

**Description :** When enabling aerial imagery in Carnation, many visibly unmarked crossings were rendered with the “marked” color.

**Root Cause :** 
The visualization used the crossing field instead of crossing:markings, so most crossings defaulted to the “marked” color. In many logs, marked crossings appeared as zebra:paired, so to be safer, the fix now explicitly treats only crossing:markings = 'no' as unmarked; all other values (e.g., zebra:paired) are considered marked.

**Resolution:**
```function getCrossingColor(d) {
  if (d['crossing:markings'] === 'no') {
    return '#dda15e'; // Unmarked
  }
  return '#FFD166';   // Marked (any other marking present)
}
```