### PR TITLE
Swap colors for footpath and kerb lowered

### DIFF
--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -1455,7 +1455,7 @@
         return '#88CCEE';
       }
       else if (isFootpath(props)) {
-        return '#CC6677';
+        return '#117733';
       }
       else if (isTrafficIsland(props)) {
         return '#882255';
@@ -1480,7 +1480,7 @@
     function getKerbColor(feature) {
       const props = feature.props || {};
       if (props['kerb'] === 'lowered') {
-        return '#117733';
+        return '#CC6677';
       }
       if (props['kerb'] === 'raised') {
         return '#AA4499';
@@ -1553,9 +1553,9 @@
         case 'Crossing Unmarked':
           return '#44AA99';
         case 'Footway':
-          return '#CC6677';
-        case 'Kerb Lowered':
           return '#117733';
+        case 'Kerb Lowered':
+          return '#CC6677';
         case 'Kerb Flushed':
           return '#332288';
         case 'Kerb Raised':


### PR DESCRIPTION
Fix styling in data-viewer/tdei-viewer.html by swapping the hex colors used for footpaths and lowered kerbs. Update covers isFootpath color, getKerbColor('lowered'), and the legend mapping so Footway now uses '#117733' and Kerb Lowered uses '#CC6677', correcting the visual classification.

Screenshot:
Left image represents viewer after colour swap : 
<img width="1470" height="956" alt="Screenshot 2026-04-23 at 4 54 26 PM" src="https://github.com/user-attachments/assets/11ad795e-4dfd-4972-bf00-e5a93eb243a4" />


