### PR TITLE
Feature task 3692 imagery change

### DIFF
--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -1384,7 +1384,7 @@
     }).addTo(map);
 
 
-    var hexagonWMS = L.tileLayer.wms('https://waprovisoimg.centralindia.cloudapp.azure.com/arcgis/services/ImageServices/Statewide_2023_1ft_4band_wsps_83h_img/ImageServer/WMSServer', {
+    var waTechImagery = L.tileLayer.wms('https://waprovisoimg.centralindia.cloudapp.azure.com/arcgis/services/ImageServices/Statewide_2023_1ft_4band_wsps_83h_img/ImageServer/WMSServer', {
       layers: 'Statewide_2023_1ft_4band_wsps_83h_img',
       format: 'image/png',
       transparent: true,
@@ -1441,7 +1441,7 @@
 
     const baseLayers = {
       'Raster': CartoDB_Positron,
-      "Imagery": hexagonWMS
+      "Imagery": waTechImagery
     };
     const position = {
       position: 'topleft',

--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -1200,8 +1200,7 @@
         <div class="disclaimer-box">
           <i class="bi bi-exclamation-circle"></i>
           <span class="disclaimer-text">
-            <strong>Known Issue:</strong> Due to a shift in imagery, you may see the mapping edges not align with
-            underlying infrastructure.
+            <strong>Notice:</strong> Images may take a moment to load. We appreciate your patience.
           </span>
         </div>
 

--- a/data-viewer/tdei-viewer.html
+++ b/data-viewer/tdei-viewer.html
@@ -1384,11 +1384,11 @@
     }).addTo(map);
 
 
-    var hexagonWMS = L.tileLayer.wms('https://waprovisoimg.centralindia.cloudapp.azure.com/streaming/wms', {
-      layers: 'HxGN_Imagery',
+    var hexagonWMS = L.tileLayer.wms('https://waprovisoimg.centralindia.cloudapp.azure.com/arcgis/services/ImageServices/Statewide_2023_1ft_4band_wsps_83h_img/ImageServer/WMSServer', {
+      layers: 'Statewide_2023_1ft_4band_wsps_83h_img',
       format: 'image/png',
       transparent: true,
-      attribution: ' Hexagon WMS',
+      attribution: ' WA Tech',
       crs: L.CRS.EPSG4326,
       maxZoom: 22
     });


### PR DESCRIPTION
This pull request updates the imagery base layer in the `data-viewer/tdei-viewer.html` file to use a new WMS source and updates related references accordingly.

**Map imagery source update:**

* Replaced the `hexagonWMS` tile layer with a new `waTechImagery` WMS tile layer, updating the URL, layer name, attribution, and variable name to reference the new WA Tech imagery service.
* Updated the `baseLayers` object to use `waTechImagery` instead of `hexagonWMS` for the "Imagery" base layer option.

<img width="1470" height="956" alt="Screenshot 2026-06-01 at 9 41 31 PM" src="https://github.com/user-attachments/assets/2fc39269-a696-4529-913d-e922ffb49891" />

